### PR TITLE
Max body size

### DIFF
--- a/Sources/CatbirdApp/AppConfiguration.swift
+++ b/Sources/CatbirdApp/AppConfiguration.swift
@@ -14,6 +14,8 @@ public struct AppConfiguration {
 
     /// The directory for mocks.
     public let mocksDirectory: URL
+
+    public let maxBodySize: String
 }
 
 extension AppConfiguration {
@@ -36,9 +38,11 @@ extension AppConfiguration {
             return url
         }()
 
+        let maxBodySize = enviroment["CATBIRD_MAX_BODY_SIZE", default: "50mb"]
+
         if let path = enviroment["CATBIRD_PROXY_URL"], let url = URL(string: path) {
-            return AppConfiguration(mode: .write(url), mocksDirectory: mocksDirectory)
+            return AppConfiguration(mode: .write(url), mocksDirectory: mocksDirectory, maxBodySize: maxBodySize)
         }
-        return AppConfiguration(mode: .read, mocksDirectory: mocksDirectory)
+        return AppConfiguration(mode: .read, mocksDirectory: mocksDirectory, maxBodySize: maxBodySize)
     }
 }

--- a/Sources/CatbirdApp/configure.swift
+++ b/Sources/CatbirdApp/configure.swift
@@ -10,6 +10,7 @@ public struct CatbirdInfo: Content {
 }
 
 public func configure(_ app: Application, _ configuration: AppConfiguration) throws {
+    app.routes.defaultMaxBodySize = ByteCount(stringLiteral: configuration.maxBodySize) 
     let info = CatbirdInfo.current
 
     // MARK: - Stores

--- a/Tests/CatbirdAppTests/App/AppConfigurationTests.swift
+++ b/Tests/CatbirdAppTests/App/AppConfigurationTests.swift
@@ -7,14 +7,17 @@ final class AppConfigurationTests: XCTestCase {
         let config = try AppConfiguration.detect(from: [:])
         XCTAssertEqual(config.mode, .read)
         XCTAssertEqual(config.mocksDirectory.absoluteString, AppConfiguration.sourceDir)
+        XCTAssertEqual(config.maxBodySize, "50mb")
     }
 
     func testDetectWriteMode() throws {
         let config = try AppConfiguration.detect(from: [
-            "CATBIRD_PROXY_URL": "/"
+            "CATBIRD_PROXY_URL": "/",
+            "CATBIRD_MAX_BODY_SIZE": "1kb"
         ])
         XCTAssertEqual(config.mode, .write(URL(string: "/")!))
         XCTAssertEqual(config.mocksDirectory.absoluteString, AppConfiguration.sourceDir)
+        XCTAssertEqual(config.maxBodySize, "1kb")
     }
 
 }

--- a/Tests/CatbirdAppTests/App/AppTestCase.swift
+++ b/Tests/CatbirdAppTests/App/AppTestCase.swift
@@ -10,7 +10,10 @@ class AppTestCase: XCTestCase {
     }
 
     func setUpApp(mode: AppConfiguration.Mode) throws {
-        let config = AppConfiguration(mode: mode, mocksDirectory: URL(string: mocksDirectory)!)
+        let config = AppConfiguration(
+            mode: mode,
+            mocksDirectory: URL(string: mocksDirectory)!,
+            maxBodySize: "50kb")
         app = Application(.testing)
         try configure(app, config)
     }
@@ -18,6 +21,7 @@ class AppTestCase: XCTestCase {
     override func setUp() {
         super.setUp()
         XCTAssertNoThrow(try setUpApp(mode: .read))
+        XCTAssertEqual(app.routes.defaultMaxBodySize, 51200)
     }
 
     override func tearDown() {


### PR DESCRIPTION
Fix 413 Payload Too Large errors in tests

```swift
// Increases the streaming body collection limit to 500kb
app.routes.defaultMaxBodySize = "500kb"
```

https://docs.vapor.codes/4.0/routing/