### PR TITLE
Fix RedirectMiddleware

### DIFF
--- a/Sources/CatbirdApp/AppConfiguration.swift
+++ b/Sources/CatbirdApp/AppConfiguration.swift
@@ -27,20 +27,20 @@ extension AppConfiguration {
 
     /// Detect application configuration.
     public static func detect(
-        from enviroment: [String: String] = ProcessInfo.processInfo.environment
+        from environment: [String: String] = ProcessInfo.processInfo.environment
     ) throws -> AppConfiguration {
 
         let mocksDirectory = try { () throws -> URL in
-            let path = enviroment["CATBIRD_MOCKS_DIR", default: sourceDir]
+            let path = environment["CATBIRD_MOCKS_DIR", default: sourceDir]
             guard let url = URL(string: path) else {
                 fatalError("Invalid URL CATBIRD_MOCKS_DIR=\(path)")
             }
             return url
         }()
 
-        let maxBodySize = enviroment["CATBIRD_MAX_BODY_SIZE", default: "50mb"]
+        let maxBodySize = environment["CATBIRD_MAX_BODY_SIZE", default: "50mb"]
 
-        if let path = enviroment["CATBIRD_PROXY_URL"], let url = URL(string: path) {
+        if let path = environment["CATBIRD_PROXY_URL"], let url = URL(string: path) {
             return AppConfiguration(mode: .write(url), mocksDirectory: mocksDirectory, maxBodySize: maxBodySize)
         }
         return AppConfiguration(mode: .read, mocksDirectory: mocksDirectory, maxBodySize: maxBodySize)

--- a/Sources/CatbirdApp/Middlewares/RedirectMiddleware.swift
+++ b/Sources/CatbirdApp/Middlewares/RedirectMiddleware.swift
@@ -11,10 +11,13 @@ final class RedirectMiddleware: Middleware {
     // MARK: - Middleware
 
     func respond(to request: Request, chainingTo next: Responder) -> EventLoopFuture<Response> {
+        var headers = request.headers
+        headers.remove(name: "Host")
+        
         var clientRequest = ClientRequest(
             method: request.method,
             url: redirectURI,
-            headers: request.headers,
+            headers: headers,
             body: request.body.data)
 
         clientRequest.url.string += request.url.string

--- a/Tests/CatbirdAppTests/Helpers/JokeAPI.swift
+++ b/Tests/CatbirdAppTests/Helpers/JokeAPI.swift
@@ -17,6 +17,7 @@ struct JokeAPI {
 
     /// Required headers for all requests.
     let headers: HTTPHeaders = [
+        "Host": "127.0.0.1:8080",
         "Accept": "text/plain",
         "User-Agent": "Catbird (\(CatbirdInfo.current.github)"
     ]


### PR DESCRIPTION
Catbird doesn't work in write mode when CATBIRD_PROXY_URL has HTTPS scheme. Vapor adds `Host: 127.0.0.1:8080` header. In this case the certificate error occurs.

I remove `Host` header in `RedirectMiddleware` to prevent this issue.
Also fixed a typo.