### PR TITLE
Add scripts to generate certificate and add it to the macOS Keychain and iOS Keychain

### DIFF
--- a/Scripts/add-certificate-to-ios-keychain.sh
+++ b/Scripts/add-certificate-to-ios-keychain.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -e
+
+CERT_FILE=root-ca.pem
+if ! test -f "$CERT_FILE"; then
+    echo "$CERT_FILE file doesn't exists. Generate it using generate-self-signed-certificate.sh"
+    exit 1
+fi
+
+# Find booted iOS Simulator
+while true; do
+  export UDID=$(xcrun simctl list devices | grep "(Booted)" | grep -E -o -i "([0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12})")  
+  if [ -z "$UDID" ]
+  then
+    echo "Please launch an iOS Simulator in which you would like to install certificate and press any key"
+    read input
+  else
+    break
+  fi
+done
+
+# Add certificate to iOS Simulator
+echo "Adding certificate to iOS Sumulator..."
+xcrun simctl keychain booted add-root-cert root-ca.pem
+
+# Restart booted iOS Simulator
+echo "Restarning iOS Sumulator..."
+xcrun simctl shutdown $UDID
+xcrun simctl boot $UDID
+
+echo "Certificate has been successfully added to the iOS Simulator Keychain"

--- a/Scripts/add-certificate-to-system-keychain.sh
+++ b/Scripts/add-certificate-to-system-keychain.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+CERT_FILE=root-ca.pem
+if ! test -f "$CERT_FILE"; then
+    echo "$CERT_FILE file doesn't exists. Generate it using generate-certificate.sh."
+    exit 1
+fi
+
+# Add certificate to macOS Keychain
+echo "You will be promted to authenticate to mark certificate as trusted"
+
+# Get path to the local keychain and trim whitespaces and quotation marks symbol
+LOGIN_KEYCHAIN="$(security login-keychain | sed 's/[[:space:]]*"//g')"
+security add-trusted-cert -k $LOGIN_KEYCHAIN root-ca.pem
+
+echo "Certificate has been successfully added to the macOS Keychain"

--- a/Scripts/cert.config
+++ b/Scripts/cert.config
@@ -1,0 +1,19 @@
+[ ca ]
+default_ca    = CA_default
+[ CA_default ]
+default_md    = sha256
+[ v3_ca ]
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid:always,issuer
+basicConstraints = critical,CA:true
+keyUsage=critical,keyCertSign
+extendedKeyUsage = serverAuth,clientAuth
+[ req ]
+prompt = no
+distinguished_name    = req_distinguished_name
+[ req_distinguished_name ]
+C=RU
+L=RU
+O=Catbird
+CN=Catbird
+OU=Catbird

--- a/Scripts/extract-certificate-from-keychain.sh
+++ b/Scripts/extract-certificate-from-keychain.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+
+# Get an existing Catbird certificate
+security find-certificate -c Catbird -p > root-ca.pem

--- a/Scripts/generate-self-signed-certificate.sh
+++ b/Scripts/generate-self-signed-certificate.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -e
+
+CONFIG_FILE=cert.config
+if ! test -f "$CONFIG_FILE"; then
+    echo "$CONFIG_FILE file doesn't exists. Add cert.config file with certificate configuration."
+    exit 1
+fi
+
+echo "Creating new certificate from cert.config"
+
+echo "Enter password for new certificate."
+read -s -p  "Password: " password
+
+# Generate RSA Key
+openssl genrsa -aes256 -passout pass:"$password" -out key.pem 2048
+
+# Generate the self-signed certificate and private key
+openssl req -x509 -new -nodes -passin pass:"$password" -config cert.config -key key.pem -sha256 -extensions v3_ca -days 365 -out root-ca.pem
+
+# Cleanup
+rm key.pem
+
+echo "Certificate created: root_ca.pem"


### PR DESCRIPTION
`Scripts/generate-self-signed-certificate.sh` — generates self signed certificate (`root-ca.pem`) using `Scripts/cert.config` config file.
`Scripts/extract-certificate-from-keychain.sh` — extracts certificate from the local macOS Keychain
`Scripts/add-certificate-to-system-keychain.sh` — adds a certificate to the local macOS Keychain
`Scripts/add-certificate-to-ios-keychain.sh` — adds a certificate to the booted iOS Simulator

Closes #41 