### PR TITLE
Fix Request.BodyStream deinitialized before closing

### DIFF
--- a/Packages/CatbirdApp/Sources/CatbirdApp/Middlewares/RedirectMiddleware.swift
+++ b/Packages/CatbirdApp/Sources/CatbirdApp/Middlewares/RedirectMiddleware.swift
@@ -11,27 +11,29 @@ final class RedirectMiddleware: Middleware {
     // MARK: - Middleware
 
     func respond(to request: Request, chainingTo next: Responder) -> EventLoopFuture<Response> {
-        var headers = request.headers
-        headers.remove(name: "Host")
-        
-        var clientRequest = ClientRequest(
-            method: request.method,
-            url: redirectURI,
-            headers: headers,
-            body: request.body.data)
+        return request.body.collect(max: nil).flatMap { (body: ByteBuffer?) -> EventLoopFuture<Response> in
+            var headers = request.headers
+            headers.remove(name: "Host")
 
-        clientRequest.url.string += request.url.string
+            var clientRequest = ClientRequest(
+                method: request.method,
+                url: self.redirectURI,
+                headers: headers,
+                body: request.body.data)
 
-        return request
-            .client
-            .send(clientRequest)
-            .map { (response: ClientResponse) -> Response in
-                let body = response.body.map { Response.Body(buffer: $0) } ?? .empty
-                return Response(
-                    status: response.status,
-                    version: request.version,
-                    headers: response.headers,
-                    body: body)
-            }
+            clientRequest.url.string += request.url.string
+
+            return request
+                .client
+                .send(clientRequest)
+                .map { (response: ClientResponse) -> Response in
+                    let body = response.body.map { Response.Body(buffer: $0) } ?? .empty
+                    return Response(
+                        status: response.status,
+                        version: request.version,
+                        headers: response.headers,
+                        body: body)
+                }
+        }
     }
 }


### PR DESCRIPTION
Close: #45 

If the Content-Length and the size of the request body do not match, then Vapor processes this request as a stream.

`Vapor.Request.body.data` gives only the first part of the request. After that, the request body is deinitialized without closing, because there was no one to read the remaining data from it.

