### PR TITLE
Simple HTTP Proxy 

### DIFF
--- a/Packages/CatbirdApp/Sources/CatbirdApp/Common/FileDirectoryPath.swift
+++ b/Packages/CatbirdApp/Sources/CatbirdApp/Common/FileDirectoryPath.swift
@@ -9,7 +9,7 @@ struct FileDirectoryPath {
     }
 
     func preferredFileURL(for request: Request) -> URL {
-        var fileUrl = url.appendingPathComponent(request.url.string)
+        var fileUrl = fileURL(for: request)
 
         guard fileUrl.pathExtension.isEmpty else {
             return fileUrl
@@ -21,7 +21,7 @@ struct FileDirectoryPath {
     }
 
     func filePaths(for request: Request) -> [String] {
-        let fileUrl = url.appendingPathComponent(request.url.string)
+        let fileUrl = fileURL(for: request)
 
         var urls: [URL] = []
         if fileUrl.pathExtension.isEmpty {
@@ -31,5 +31,17 @@ struct FileDirectoryPath {
         }
         urls.append(fileUrl)
         return urls.map { $0.absoluteString }
+    }
+
+    private func fileURL(for request: Request) -> URL {
+        var fileUrl = url
+        if let host = request.url.host {
+            fileUrl.appendPathComponent(host)
+        }
+        fileUrl.appendPathComponent(request.url.path)
+        if fileUrl.absoluteString.hasSuffix("/") {
+            fileUrl.appendPathComponent("index")
+        }
+        return fileUrl
     }
 }

--- a/Packages/CatbirdApp/Sources/CatbirdApp/Common/HTTPClientSupport.swift
+++ b/Packages/CatbirdApp/Sources/CatbirdApp/Common/HTTPClientSupport.swift
@@ -39,9 +39,5 @@ extension ClientResponse {
     fileprivate func response(version: HTTPVersion) -> Response {
         let body = body.map { Response.Body(buffer: $0) } ?? .empty
         return Response(status: status, version: version, headers: headers, body: body)
-
-//        var headers = self.headers
-//        headers.remove(name: .contentLength)
-//        return Response(status: status, version: version, headers: headers, body: .empty)
     }
 }

--- a/Packages/CatbirdApp/Sources/CatbirdApp/Common/HTTPClientSupport.swift
+++ b/Packages/CatbirdApp/Sources/CatbirdApp/Common/HTTPClientSupport.swift
@@ -37,11 +37,11 @@ extension HTTPHeaders {
 extension ClientResponse {
     /// Convert to Server Response.
     fileprivate func response(version: HTTPVersion) -> Response {
-//        let body = body.map { Response.Body(buffer: $0) } ?? .empty
-//        return Response(status: status, version: version, headers: headers, body: body)
+        let body = body.map { Response.Body(buffer: $0) } ?? .empty
+        return Response(status: status, version: version, headers: headers, body: body)
 
-        var headers = self.headers
-        headers.remove(name: .contentLength)
-        return Response(status: status, version: version, headers: headers, body: .empty)
+//        var headers = self.headers
+//        headers.remove(name: .contentLength)
+//        return Response(status: status, version: version, headers: headers, body: .empty)
     }
 }

--- a/Packages/CatbirdApp/Sources/CatbirdApp/Common/HTTPClientSupport.swift
+++ b/Packages/CatbirdApp/Sources/CatbirdApp/Common/HTTPClientSupport.swift
@@ -1,0 +1,47 @@
+import Vapor
+
+extension Request {
+    /// Send HTTP request.
+    ///
+    /// - Parameter configure: client request configuration function.
+    /// - Returns: Server response.
+    func send(configure: ((inout ClientRequest) -> Void)? = nil) -> EventLoopFuture<Response> {
+        return body
+            .collect(max: nil)
+            .flatMap { (bytesBuffer: ByteBuffer?) -> EventLoopFuture<Response> in
+                var clientRequest = self.clientRequest(body: bytesBuffer)
+                configure?(&clientRequest)
+                return self.client.send(clientRequest).map { (clientResponse: ClientResponse) -> Response in
+                    clientResponse.response(version: self.version)
+                }
+            }
+    }
+
+    /// Convert to HTTP client request.
+    private func clientRequest(body: ByteBuffer?) -> ClientRequest {
+        var headers = self.headers
+        if let host = headers.first(name: "Host") {
+            headers.replaceOrAdd(name: "X-Forwarded-Host", value: host)
+            headers.remove(name: "Host")
+        }
+        return ClientRequest(method: method, url: url, headers: headers, body: body)
+    }
+}
+
+extension HTTPHeaders {
+    fileprivate var contentLength: Int? {
+        first(name: "Content-Length").flatMap { Int($0) }
+    }
+}
+
+extension ClientResponse {
+    /// Convert to Server Response.
+    fileprivate func response(version: HTTPVersion) -> Response {
+//        let body = body.map { Response.Body(buffer: $0) } ?? .empty
+//        return Response(status: status, version: version, headers: headers, body: body)
+
+        var headers = self.headers
+        headers.remove(name: .contentLength)
+        return Response(status: status, version: version, headers: headers, body: .empty)
+    }
+}

--- a/Packages/CatbirdApp/Sources/CatbirdApp/Common/Loggers.swift
+++ b/Packages/CatbirdApp/Sources/CatbirdApp/Common/Loggers.swift
@@ -13,7 +13,10 @@ enum Loggers {
         return Logging.Logger(label: CatbirdInfo.current.domain)
 #else
         return Logging.Logger(label: CatbirdInfo.current.domain) {
-            OSLogHandler(subsystem: $0, category: category)
+            Logging.MultiplexLogHandler([
+                OSLogHandler(subsystem: $0, category: category),
+                Logging.StreamLogHandler.standardOutput(label: $0)
+            ])
         }
 #endif
     }

--- a/Packages/CatbirdApp/Sources/CatbirdApp/Middlewares/ProxyMiddleware.swift
+++ b/Packages/CatbirdApp/Sources/CatbirdApp/Middlewares/ProxyMiddleware.swift
@@ -1,0 +1,31 @@
+import Vapor
+
+final class ProxyMiddleware: Middleware {
+
+    func respond(to request: Request, chainingTo next: Responder) -> EventLoopFuture<Response> {
+        // Not handle direct request to catbird
+//        guard let url = URL(string: request.url.string) else {
+//            return next.respond(to: request)
+//        }
+//        print(url)
+
+        if request.url.host == nil {
+            request.logger.info("Proxy break \(request.method) \(request.url)")
+            return next.respond(to: request)
+        }
+
+//        request.logger.info("Proxy \(request.method) \(url), scheme \(request.url.scheme ?? "<nil>")")
+
+        var url = request.url
+        if url.scheme == nil {
+            url.scheme = url.port == 443 ? "https" : "http"
+        }
+
+        request.logger.info("Proxy \(request.method) \(url), scheme \(url.scheme ?? "<nil>")")
+
+        // Send request to real host
+        return request.send {
+            $0.url = url
+        }
+    }
+}

--- a/Packages/CatbirdApp/Sources/CatbirdApp/Middlewares/ProxyMiddleware.swift
+++ b/Packages/CatbirdApp/Sources/CatbirdApp/Middlewares/ProxyMiddleware.swift
@@ -3,29 +3,22 @@ import Vapor
 final class ProxyMiddleware: Middleware {
 
     func respond(to request: Request, chainingTo next: Responder) -> EventLoopFuture<Response> {
-        // Not handle direct request to catbird
-//        guard let url = URL(string: request.url.string) else {
-//            return next.respond(to: request)
-//        }
-//        print(url)
-
         if request.url.host == nil {
             request.logger.info("Proxy break \(request.method) \(request.url)")
             return next.respond(to: request)
         }
+        return next.respond(to: request).notFound {
+            var url = request.url
+            if url.scheme == nil {
+                url.scheme = url.port == 443 ? "https" : "http"
+            }
 
-//        request.logger.info("Proxy \(request.method) \(url), scheme \(request.url.scheme ?? "<nil>")")
+            request.logger.info("Proxy \(request.method) \(url), scheme \(url.scheme ?? "<nil>")")
 
-        var url = request.url
-        if url.scheme == nil {
-            url.scheme = url.port == 443 ? "https" : "http"
-        }
-
-        request.logger.info("Proxy \(request.method) \(url), scheme \(url.scheme ?? "<nil>")")
-
-        // Send request to real host
-        return request.send {
-            $0.url = url
+            // Send request to real host
+            return request.send {
+                $0.url = url
+            }
         }
     }
 }

--- a/Packages/CatbirdApp/Sources/CatbirdApp/Stores/FileResponseStore.swift
+++ b/Packages/CatbirdApp/Sources/CatbirdApp/Stores/FileResponseStore.swift
@@ -21,7 +21,8 @@ final class FileResponseStore: ResponseStore {
         guard fileExists(atPath: path) else {
             return request.eventLoop.makeFailedFuture(Abort(.notFound))
         }
-        let response = request.fileio.streamFile(at: path)
+//        let response = request.fileio.streamFile(at: path)
+        let response = Response(status: .ok)
         return request.eventLoop.makeSucceededFuture(response)
     }
 
@@ -43,7 +44,15 @@ final class FileResponseStore: ResponseStore {
     // MARK: - Private
 
     private func filePath(for request: Request) -> String {
-        return directory.absoluteString + request.url.path
+        var url = directory
+        if let host = request.url.host {
+            url.appendPathComponent(host)
+        }
+        url.appendPathComponent(request.url.path)
+        if url.absoluteString.hasSuffix("/") {
+            url.appendPathComponent("index")
+        }
+        return url.absoluteString
     }
 
     private func fileExists(atPath path: String) -> Bool {

--- a/Packages/CatbirdApp/Sources/CatbirdApp/Stores/FileResponseStore.swift
+++ b/Packages/CatbirdApp/Sources/CatbirdApp/Stores/FileResponseStore.swift
@@ -21,8 +21,7 @@ final class FileResponseStore: ResponseStore {
         guard fileExists(atPath: path) else {
             return request.eventLoop.makeFailedFuture(Abort(.notFound))
         }
-//        let response = request.fileio.streamFile(at: path)
-        let response = Response(status: .ok)
+        let response = request.fileio.streamFile(at: path)
         return request.eventLoop.makeSucceededFuture(response)
     }
 

--- a/Packages/CatbirdApp/Sources/CatbirdApp/configure.swift
+++ b/Packages/CatbirdApp/Sources/CatbirdApp/configure.swift
@@ -15,37 +15,7 @@ public struct CatbirdInfo: Content {
 
 public func configure(_ app: Application, _ configuration: AppConfiguration) throws {
     app.routes.defaultMaxBodySize = ByteCount(stringLiteral: configuration.maxBodySize)
-//    app.logger.logLevel = .trace
     let info = CatbirdInfo.current
-
-    // /Users/alexander.ignatiev/Documents/Notes/podlodka/hacker_news/server/go/cert/server.crt
-    // /Users/alexander.ignatiev/Documents/Notes/podlodka/hacker_news/server/go/cert/server.key
-
-/*
-
- CATBIRD_CERT_PATH
- CATBIRD_KEY_PATH
-
- */
-    
-//    try app.http.server.configuration.tlsConfiguration = .makeServerConfiguration(
-//        certificateChain: NIOSSLCertificate.fromPEMFile("/Users/alexander.ignatiev/GitHub/catbird/cert.pem").map { .certificate($0) },
-//        privateKey: .file("/Users/alexander.ignatiev/GitHub/catbird/cert.key")
-//    )
-//    app.http.server.configuration.supportVersions = [.one]
-
-//    try app.http.server.configuration.tlsConfiguration = .makeServerConfiguration(
-//        certificateChain: NIOSSLCertificate.fromPEMFile("/Users/alexander.ignatiev/Developer/proxyman/proxyman-cert.pem").map { .certificate($0) },
-//        privateKey: .file("/Users/alexander.ignatiev/Developer/proxyman/proxyman-key.pem")
-//    )
-
-//    app.http.server.configuration.tlsConfiguration
-
-//    let tlsConfiguration = TLSConfiguration.makeServerConfiguration(
-//        certificateChain: try NIOSSLCertificate.fromPEMFile("/Users/alexander.ignatiev/GitHub/catbird/cert.pem").map { .certificate($0) },
-//        privateKey: .file("/Users/alexander.ignatiev/GitHub/catbird/cert.key"))
-//
-//    let ssl = try NIOSSLContext(configuration: tlsConfiguration)
 
     // MARK: - Stores
 
@@ -61,30 +31,11 @@ public func configure(_ app: Application, _ configuration: AppConfiguration) thr
 
     // MARK: - Register Middleware
 
-//    let httpTunnel = AnyMiddleware { request, next in
-//        guard request.method == .CONNECT else {
-//            return next.respond(to: request)
-//        }
-//        request.logger.info("http tunnel \(request.headers)")
-////        let response = Response(status: .movedPermanently, headers: ["Location": "http://ya.ru"])
-//        let response = Response(status: .ok, body: .init(stream: { writer in
-//            writer.write(.buffer(ByteBuffer.init(integer: 5)))
-//        }, count: 1))
-//        return request.eventLoop.makeSucceededFuture(response)
-//    }
-//    app.middleware.use(httpTunnel)
-
     // Pubic resource for web page
     app.middleware.use(FileMiddleware(publicDirectory: app.directory.publicDirectory))
-    switch configuration.mode {
-    case .read:
-        app.logger.info("Read mode")
-        // try read from static mocks if route not found
-        app.middleware.use(AnyMiddleware.notFound(fileStore.response))
-        // try read from dynamic mocks
-        app.middleware.use(AnyMiddleware.notFound(inMemoryStore.response))
-    case .write(let url):
-        app.logger.info("Write mode")
+
+    if configuration.isRecordMode {
+        app.logger.info("Record mode")
         app.http.client.configuration.decompression = .enabled(limit: .none)
         // capture response and write to file
         app.middleware.use(AnyMiddleware.capture { request, response in
@@ -95,27 +46,19 @@ public func configure(_ app: Application, _ configuration: AppConfiguration) thr
             let mock = ResponseMock(status: Int(response.status.code), body: response.body.data)
             return fileStore.perform(.update(pattern, mock), for: request).map { _ in response }
         })
-        // redirect request to another server
-//        app.middleware.use(RedirectMiddleware(serverURL: url))
+    } else {
+        app.logger.info("Read mode")
+        // try read from static mocks if route not found
+        app.middleware.use(AnyMiddleware.notFound(fileStore.response))
+        // try read from dynamic mocks
+        app.middleware.use(AnyMiddleware.notFound(inMemoryStore.response))
+    }
+    if let url = configuration.redirectUrl {
+        app.middleware.use(RedirectMiddleware(serverURL: url))
+    }
+    if configuration.proxyEnabled {
         app.middleware.use(ProxyMiddleware())
     }
-
-//    let config = Config()
-//
-//    if config.recordingMode {
-//        app.middleware.use(RecordingMiddleware(store: fileStore))
-//    } else {
-//        // try read from static mocks if route not found
-//        app.middleware.use(AnyMiddleware.notFound(fileStore.response))
-//        // try read from dynamic mocks
-//        app.middleware.use(AnyMiddleware.notFound(inMemoryStore.response))
-//    }
-//    if let url = config.redirectUrl {
-//        app.middleware.use(RedirectMiddleware(serverURL: url))
-//    }
-//    if config.proxyEnabled {
-//        app.middleware.use(ProxyMiddleware())
-//    }
 
     // MARK: - Register Routes
 

--- a/Packages/CatbirdApp/Sources/CatbirdApp/configure.swift
+++ b/Packages/CatbirdApp/Sources/CatbirdApp/configure.swift
@@ -39,7 +39,7 @@ public func configure(_ app: Application, _ configuration: AppConfiguration) thr
 //        privateKey: .file("/Users/alexander.ignatiev/Developer/proxyman/proxyman-key.pem")
 //    )
 
-    app.http.server.configuration.tlsConfiguration
+//    app.http.server.configuration.tlsConfiguration
 
 //    let tlsConfiguration = TLSConfiguration.makeServerConfiguration(
 //        certificateChain: try NIOSSLCertificate.fromPEMFile("/Users/alexander.ignatiev/GitHub/catbird/cert.pem").map { .certificate($0) },
@@ -61,27 +61,24 @@ public func configure(_ app: Application, _ configuration: AppConfiguration) thr
 
     // MARK: - Register Middleware
 
-    let httpTunnel = AnyMiddleware { request, next in
-        guard request.method == .CONNECT else {
-            return next.respond(to: request)
-        }
-        request.logger.info("http tunnel \(request.headers)")
-//        let response = Response(status: .movedPermanently, headers: ["Location": "http://ya.ru"])
-        let response = Response(status: .ok, body: .init(stream: { writer in
-            writer.write(.buffer(ByteBuffer.init(integer: 5)))
-        }, count: 1))
-        return request.eventLoop.makeSucceededFuture(response)
-    }
-    app.middleware.use(httpTunnel)
+//    let httpTunnel = AnyMiddleware { request, next in
+//        guard request.method == .CONNECT else {
+//            return next.respond(to: request)
+//        }
+//        request.logger.info("http tunnel \(request.headers)")
+////        let response = Response(status: .movedPermanently, headers: ["Location": "http://ya.ru"])
+//        let response = Response(status: .ok, body: .init(stream: { writer in
+//            writer.write(.buffer(ByteBuffer.init(integer: 5)))
+//        }, count: 1))
+//        return request.eventLoop.makeSucceededFuture(response)
+//    }
+//    app.middleware.use(httpTunnel)
 
     // Pubic resource for web page
     app.middleware.use(FileMiddleware(publicDirectory: app.directory.publicDirectory))
     switch configuration.mode {
     case .read:
         app.logger.info("Read mode")
-//        app.middleware.use(AnyMiddleware.notFound({ request in
-//            request.eventLoop.makeSucceededFuture(Response(status: .imATeapot, version: request.version))
-//        }))
         // try read from static mocks if route not found
         app.middleware.use(AnyMiddleware.notFound(fileStore.response))
         // try read from dynamic mocks
@@ -95,9 +92,9 @@ public func configure(_ app: Application, _ configuration: AppConfiguration) thr
             return fileStore.perform(.update(pattern, mock), for: request).map { _ in response }
         })
         // redirect request to another server
-        app.middleware.use(RedirectMiddleware(serverURL: url))
+//        app.middleware.use(RedirectMiddleware(serverURL: url))
+        app.middleware.use(ProxyMiddleware())
     }
-//    app.middleware.use(ProxyMiddleware())
 
 //    let config = Config()
 //

--- a/Packages/CatbirdApp/Sources/CatbirdApp/configure.swift
+++ b/Packages/CatbirdApp/Sources/CatbirdApp/configure.swift
@@ -34,6 +34,9 @@ public func configure(_ app: Application, _ configuration: AppConfiguration) thr
     // Pubic resource for web page
     app.middleware.use(FileMiddleware(publicDirectory: app.directory.publicDirectory))
 
+    if configuration.proxyEnabled {
+        app.middleware.use(ProxyMiddleware()) // catch 404
+    }
     if configuration.isRecordMode {
         app.logger.info("Record mode")
         app.http.client.configuration.decompression = .enabled(limit: .none)
@@ -55,9 +58,6 @@ public func configure(_ app: Application, _ configuration: AppConfiguration) thr
     }
     if let url = configuration.redirectUrl {
         app.middleware.use(RedirectMiddleware(serverURL: url))
-    }
-    if configuration.proxyEnabled {
-        app.middleware.use(ProxyMiddleware())
     }
 
     // MARK: - Register Routes

--- a/Packages/CatbirdApp/Sources/CatbirdApp/configure.swift
+++ b/Packages/CatbirdApp/Sources/CatbirdApp/configure.swift
@@ -1,5 +1,6 @@
 import CatbirdAPI
 import Vapor
+import NIOSSL
 
 public struct CatbirdInfo: Content {
     public static let current = CatbirdInfo(
@@ -14,7 +15,37 @@ public struct CatbirdInfo: Content {
 
 public func configure(_ app: Application, _ configuration: AppConfiguration) throws {
     app.routes.defaultMaxBodySize = ByteCount(stringLiteral: configuration.maxBodySize)
+//    app.logger.logLevel = .trace
     let info = CatbirdInfo.current
+
+    // /Users/alexander.ignatiev/Documents/Notes/podlodka/hacker_news/server/go/cert/server.crt
+    // /Users/alexander.ignatiev/Documents/Notes/podlodka/hacker_news/server/go/cert/server.key
+
+/*
+
+ CATBIRD_CERT_PATH
+ CATBIRD_KEY_PATH
+
+ */
+    
+//    try app.http.server.configuration.tlsConfiguration = .makeServerConfiguration(
+//        certificateChain: NIOSSLCertificate.fromPEMFile("/Users/alexander.ignatiev/GitHub/catbird/cert.pem").map { .certificate($0) },
+//        privateKey: .file("/Users/alexander.ignatiev/GitHub/catbird/cert.key")
+//    )
+//    app.http.server.configuration.supportVersions = [.one]
+
+//    try app.http.server.configuration.tlsConfiguration = .makeServerConfiguration(
+//        certificateChain: NIOSSLCertificate.fromPEMFile("/Users/alexander.ignatiev/Developer/proxyman/proxyman-cert.pem").map { .certificate($0) },
+//        privateKey: .file("/Users/alexander.ignatiev/Developer/proxyman/proxyman-key.pem")
+//    )
+
+    app.http.server.configuration.tlsConfiguration
+
+//    let tlsConfiguration = TLSConfiguration.makeServerConfiguration(
+//        certificateChain: try NIOSSLCertificate.fromPEMFile("/Users/alexander.ignatiev/GitHub/catbird/cert.pem").map { .certificate($0) },
+//        privateKey: .file("/Users/alexander.ignatiev/GitHub/catbird/cert.key"))
+//
+//    let ssl = try NIOSSLContext(configuration: tlsConfiguration)
 
     // MARK: - Stores
 
@@ -28,13 +59,29 @@ public func configure(_ app: Application, _ configuration: AppConfiguration) thr
         store: InMemoryResponseStore(),
         logger: Loggers.inMemoryStore)
 
-    // MARK: - Register Middlewares
+    // MARK: - Register Middleware
+
+    let httpTunnel = AnyMiddleware { request, next in
+        guard request.method == .CONNECT else {
+            return next.respond(to: request)
+        }
+        request.logger.info("http tunnel \(request.headers)")
+//        let response = Response(status: .movedPermanently, headers: ["Location": "http://ya.ru"])
+        let response = Response(status: .ok, body: .init(stream: { writer in
+            writer.write(.buffer(ByteBuffer.init(integer: 5)))
+        }, count: 1))
+        return request.eventLoop.makeSucceededFuture(response)
+    }
+    app.middleware.use(httpTunnel)
 
     // Pubic resource for web page
     app.middleware.use(FileMiddleware(publicDirectory: app.directory.publicDirectory))
     switch configuration.mode {
     case .read:
         app.logger.info("Read mode")
+//        app.middleware.use(AnyMiddleware.notFound({ request in
+//            request.eventLoop.makeSucceededFuture(Response(status: .imATeapot, version: request.version))
+//        }))
         // try read from static mocks if route not found
         app.middleware.use(AnyMiddleware.notFound(fileStore.response))
         // try read from dynamic mocks
@@ -50,6 +97,24 @@ public func configure(_ app: Application, _ configuration: AppConfiguration) thr
         // redirect request to another server
         app.middleware.use(RedirectMiddleware(serverURL: url))
     }
+//    app.middleware.use(ProxyMiddleware())
+
+//    let config = Config()
+//
+//    if config.recordingMode {
+//        app.middleware.use(RecordingMiddleware(store: fileStore))
+//    } else {
+//        // try read from static mocks if route not found
+//        app.middleware.use(AnyMiddleware.notFound(fileStore.response))
+//        // try read from dynamic mocks
+//        app.middleware.use(AnyMiddleware.notFound(inMemoryStore.response))
+//    }
+//    if let url = config.redirectUrl {
+//        app.middleware.use(RedirectMiddleware(serverURL: url))
+//    }
+//    if config.proxyEnabled {
+//        app.middleware.use(ProxyMiddleware())
+//    }
 
     // MARK: - Register Routes
 

--- a/Packages/CatbirdApp/Tests/CatbirdAppTests/App/AppConfigurationTests.swift
+++ b/Packages/CatbirdApp/Tests/CatbirdAppTests/App/AppConfigurationTests.swift
@@ -5,18 +5,24 @@ final class AppConfigurationTests: XCTestCase {
 
     func testDetectReadMode() throws {
         let config = try AppConfiguration.detect(from: [:])
-        XCTAssertEqual(config.mode, .read)
+        XCTAssertEqual(config.isRecordMode, false)
+        XCTAssertEqual(config.proxyEnabled, false)
         XCTAssertEqual(config.mocksDirectory.absoluteString, AppConfiguration.sourceDir)
+        XCTAssertNil(config.redirectUrl)
         XCTAssertEqual(config.maxBodySize, "50mb")
     }
 
     func testDetectWriteMode() throws {
         let config = try AppConfiguration.detect(from: [
-            "CATBIRD_PROXY_URL": "/",
+            "CATBIRD_RECORD_MODE": "1",
+            "CATBIRD_PROXY_ENABLED": "1",
+            "CATBIRD_REDIRECT_URL": "https://example.com",
             "CATBIRD_MAX_BODY_SIZE": "1kb"
         ])
-        XCTAssertEqual(config.mode, .write(URL(string: "/")!))
+        XCTAssertEqual(config.isRecordMode, true)
+        XCTAssertEqual(config.proxyEnabled, true)
         XCTAssertEqual(config.mocksDirectory.absoluteString, AppConfiguration.sourceDir)
+        XCTAssertEqual(config.redirectUrl?.absoluteString, "https://example.com")
         XCTAssertEqual(config.maxBodySize, "1kb")
     }
 

--- a/Packages/CatbirdApp/Tests/CatbirdAppTests/App/AppTestCase.swift
+++ b/Packages/CatbirdApp/Tests/CatbirdAppTests/App/AppTestCase.swift
@@ -9,10 +9,14 @@ class AppTestCase: XCTestCase {
         willSet { app?.shutdown() }
     }
 
-    func setUpApp(redirectUrl: URL?) throws {
+    func setUpApp(
+        isRecordMode: Bool = false,
+        proxyEnabled: Bool = false,
+        redirectUrl: URL? = nil
+    ) throws {
         let config = AppConfiguration(
-            isRecordMode: redirectUrl != nil,
-            proxyEnabled: false,
+            isRecordMode: isRecordMode,
+            proxyEnabled: proxyEnabled,
             mocksDirectory: URL(string: mocksDirectory)!,
             redirectUrl: redirectUrl,
             maxBodySize: "50kb")
@@ -22,7 +26,7 @@ class AppTestCase: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        XCTAssertNoThrow(try setUpApp(redirectUrl: nil))
+        XCTAssertNoThrow(try setUpApp())
         XCTAssertEqual(app.routes.defaultMaxBodySize, 51200)
     }
 

--- a/Packages/CatbirdApp/Tests/CatbirdAppTests/App/AppTestCase.swift
+++ b/Packages/CatbirdApp/Tests/CatbirdAppTests/App/AppTestCase.swift
@@ -9,10 +9,12 @@ class AppTestCase: XCTestCase {
         willSet { app?.shutdown() }
     }
 
-    func setUpApp(mode: AppConfiguration.Mode) throws {
+    func setUpApp(redirectUrl: URL?) throws {
         let config = AppConfiguration(
-            mode: mode,
+            isRecordMode: redirectUrl != nil,
+            proxyEnabled: false,
             mocksDirectory: URL(string: mocksDirectory)!,
+            redirectUrl: redirectUrl,
             maxBodySize: "50kb")
         app = Application(.testing)
         try configure(app, config)
@@ -20,7 +22,7 @@ class AppTestCase: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        XCTAssertNoThrow(try setUpApp(mode: .read))
+        XCTAssertNoThrow(try setUpApp(redirectUrl: nil))
         XCTAssertEqual(app.routes.defaultMaxBodySize, 51200)
     }
 

--- a/Packages/CatbirdApp/Tests/CatbirdAppTests/App/AppTests.swift
+++ b/Packages/CatbirdApp/Tests/CatbirdAppTests/App/AppTests.swift
@@ -14,7 +14,7 @@ final class AppTests: AppTestCase {
     func testWriteFileMock() throws {
         // Given
         let api = JokeAPI()
-        XCTAssertNoThrow(try setUpApp(mode: .write(api.host)), """
+        XCTAssertNoThrow(try setUpApp(redirectUrl: api.host), """
         Launch the app in redirect mode to \(api.host) and write files to a folder \(mocksDirectory)
         """)
         addTeardownBlock {

--- a/Packages/CatbirdApp/Tests/CatbirdAppTests/Common/FileDirectoryPathTests.swift
+++ b/Packages/CatbirdApp/Tests/CatbirdAppTests/Common/FileDirectoryPathTests.swift
@@ -41,13 +41,57 @@ final class FileDirectoryPathTests: RequestTestCase {
     func testFilePathsForRequestWithEmptyAccept() {
         let path = FileDirectoryPath(url: URL(string: "fixtures")!)
         let request = makeRequest(
-            url: "stores",
+            url: "/stores",
             headers: ["Accept": "text/plain, application/json"]
         )
         XCTAssertEqual(path.filePaths(for: request), [
             "fixtures/stores.txt",
             "fixtures/stores.json",
             "fixtures/stores"
+        ])
+    }
+
+    func testRequestWithHost() {
+        let path = FileDirectoryPath(url: URL(string: "root")!)
+        let request = makeRequest(
+            url: "http://example.com/news.html"
+        )
+        XCTAssertEqual(
+            path.preferredFileURL(for: request),
+            URL(string: "root/example.com/news.html")!
+        )
+        XCTAssertEqual(path.filePaths(for: request), [
+            "root/example.com/news.html",
+        ])
+    }
+
+    func testRequestWithSlash() {
+        let path = FileDirectoryPath(url: URL(string: "root")!)
+        let request = makeRequest(
+            url: "http://example.com/",
+            headers: ["Accept": "text/html"]
+        )
+        XCTAssertEqual(
+            path.preferredFileURL(for: request),
+            URL(string: "root/example.com/index.html")!
+        )
+        XCTAssertEqual(path.filePaths(for: request), [
+            "root/example.com/index.html",
+            "root/example.com/index",
+        ])
+    }
+
+    func testRequestWithQuery() {
+        let path = FileDirectoryPath(url: URL(string: "root")!)
+        let request = makeRequest(
+            url: "http://example.com/item?data=123"
+        )
+        XCTAssertEqual(
+            path.preferredFileURL(for: request),
+            URL(string: "root/example.com/item")!
+        )
+        XCTAssertEqual(path.filePaths(for: request), [
+            "root/example.com/item",
         ])
     }
 }

--- a/Packages/CatbirdApp/Tests/CatbirdAppTests/Helpers/JokeAPI.swift
+++ b/Packages/CatbirdApp/Tests/CatbirdAppTests/Helpers/JokeAPI.swift
@@ -1,5 +1,11 @@
 import CatbirdApp
 import Vapor
+import Foundation
+
+/*
+ curl http://icanhazdadjoke.com/j/R7UfaahVfFd
+ curl http://icanhazdadjoke.com/j/R7UfaahVfFd --proxy http://127.0.0.1:8080
+ */
 
 /// https://icanhazdadjoke.com/api
 struct JokeAPI {
@@ -9,8 +15,11 @@ struct JokeAPI {
         var path: String { "/j/\(id)" }
     }
 
+    /// API url.
+    let url = URL(string: "https://icanhazdadjoke.com")!
+
     /// API host.
-    let host = URL(string: "https://icanhazdadjoke.com")!
+    var host: String { url.host! }
 
     /// API root directory.
     let root = "/j"
@@ -31,5 +40,4 @@ struct JokeAPI {
             id: "0ozAXv4Mmjb",
             text: "Why did the tomato blush? Because it saw the salad dressing.")
     ]
-
 }

--- a/README.md
+++ b/README.md
@@ -239,7 +239,9 @@ Run catbird with `CATBIRD_PROXY_ENABLED=1`.
 CATBIRD_PROXY_ENABLED=1 ./catbird
 ```
 
-All requests will be proxied and redirected to the real host.
+By enabling this mode, the catbird will be running as a local http proxy server. 
+You can configure your http client to use this proxy, and all requests will be proxied thought the catbird and redirected to the real host.
+It might be helpful if you don't want to change the base url of your requests.
 
 ```bash
 curl http://api.github.com/zen --proxy http://127.0.0.1:8080

--- a/README.md
+++ b/README.md
@@ -208,9 +208,42 @@ $ xed .
 
 ## Environment variables
 
-`CATBIRD_MOCKS_DIR` — Directory where static mocks are located.
+- `CATBIRD_MOCKS_DIR` — Directory where static mocks are located.
+- `CATBIRD_RECORD_MODE` —  set this variable to `1` so that the application starts recording HTTP responses along the path set in `CATBIRD_MOCKS_DIR`. Default `0`.
+- `CATBIRD_REDIRECT_URL` — set this url to forward direct requests to catbird. By default, nil. If the recording mode is not enabled, then first the responses will be searched in the mocks and only if nothing is found, the request will be forwarded.
+- `CATBIRD_PROXY_ENABLED` — set this variable to `1` to forward proxy requests to catbird. By default, `0`. If the recording mode is not enabled, then first the responses will be searched in the mocks and only if nothing is found, the request will be proxied.
 
-`CATBIRD_PROXY_URL` — If you specify this URL Catbird will run in write mode. In this mode, requests to Catbird will be redirected to the `CATBIRD_PROXY_URL`. Upon receipt of response from the server it will be written to the `CATBIRD_MOCKS_DIR` directory.
+> Catbird supports proxying only HTTP requests. HTTPS requests are not supported!
+
+### Redirect example
+
+Run catbird with `CATBIRD_REDIRECT_URL`.
+
+```bash
+CATBIRD_REDIRECT_URL=https://api.github.com ./catbird
+```
+
+All direct requests will be forwarded to `CATBIRD_REDIRECT_URL`.
+
+```bash
+curl http://127.0.0.1:8080/zen
+```
+
+The response will be returned as to the request https://api.github.com/zen
+
+### Proxy example
+
+Run catbird with `CATBIRD_PROXY_ENABLED=1`.
+
+```bash
+CATBIRD_PROXY_ENABLED=1 ./catbird
+```
+
+All requests will be proxied and redirected to the real host.
+
+```bash
+curl http://api.github.com/zen --proxy http://127.0.0.1:8080
+```
 
 ## Logs
 


### PR DESCRIPTION
Close: #40 #39 

Catbird only supports direct requests to its host.

To do this, the `CATBIRD_PROXY_URL` environment variable is set. And she was also responsible for switching to recording mode. This confused the users.

In this MR, this variable has been split into 3

- `CATBIRD_RECORD_MODE` to explicitly enable recording mode
- `CATBIRD_REDIRECT_URL` to set the url to which direct requests will be redirected
- `CATBIRD_PROXY_ENABLED` to enable proxying mode so that requests from different hosts can be redirected to a real server
