### PR TITLE
gh release upload

### DIFF
--- a/.github/scripts/gh-release-upload.sh
+++ b/.github/scripts/gh-release-upload.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Upload asset files to a GitHub Release.
+#
+# The gh cli in GitHub Actions is preinstalled in macOS, but is missing in Docker on Linux.
+# https://docs.github.com/en/rest/reference/releases#upload-a-release-asset
+
+set -eu
+
+FILE_NAME=$(basename "$FILE_PATH")
+CONTENT_TYPE=$(file -b --mime-type "$FILE_PATH")
+UPLOAD_URL="https://uploads.github.com/repos/RedMadRobot/catbird/releases/$RELEASE_ID/assets?name=$FILE_NAME"
+
+echo "Upload URL: $UPLOAD_URL"
+echo "Content-Type: $CONTENT_TYPE"
+
+curl \
+  -X POST "$UPLOAD_URL" \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github.v3+json" \
+  -H "Content-Type: $CONTENT_TYPE" \
+  --upload-file "$FILE_PATH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,9 @@ jobs:
         run: .github/scripts/linux-build.sh
         shell: bash
       - name: Upload GitHub Release Assets
-        run: gh release upload ${{ github.event.release.tag_name }} catbird-linux
+        run: .github/scripts/gh-release-upload.sh
+        shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_ID: ${{ github.event.release.id }}
+          FILE_PATH: catbird-linux


### PR DESCRIPTION
Close: #54 

The binar upload to Linux failed because the **gh** cli was not installed in the docker.

- Installing gh in docker is inconvenient.
- Third-party GitHub action were too big for that.

Based on this, a bash script was written.